### PR TITLE
Allow users to use unsafe Interchange methods less

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,4 @@ documentation = "https://docs.rs/interchange"
 keywords = ["cortex-m", "nxp", "lpc"]
 categories = ["development-tools", "embedded"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -113,6 +113,20 @@ macro_rules! interchange {
                 Self::CLIENT_CAPACITY - Self::last_claimed().load(core::sync::atomic::Ordering::SeqCst)
             }
 
+            fn is_request_state(&self) -> bool {
+                match self {
+                    Self::Request(_) => true,
+                    _ => false,
+                }
+            }
+
+            fn is_response_state(&self) -> bool {
+                match self {
+                    Self::Response(_) => true,
+                    _ => false,
+                }
+            }
+
             unsafe fn rq(self) -> Self::REQUEST {
                 match self {
                     Self::Request(request) => {


### PR DESCRIPTION
- Have `Requester.response` and `Responder.request` methods, allowing "peeking"
- Have `Requester.request_mut` and `Responder.response_mut` if the Request/Response enum variants are Default; this allows building a request/response incrementally (example use case: APDUs coming in in multiple messages), while not needing an independent "huge" buffer
- Factor out the atomic transition methods