### PR TITLE
Fix usage of unsafe cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2]- 2021-04-23
+- Soundness fix @sosthene-nitrokey
+
 ## [0.2.0]- 2021-04-23
 
 - Changes API to use references instead of moves.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interchange"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Nicolas Stalder <n@stalder.io>"]
 edition = "2018"
 description = "Request/response mechanism for embedded development, using atomics"

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ pub enum Response {
 }
 
 interchange::interchange! {
-    ExampleInterchange: (Request, Response)
+    ExampleInterchange: (Request, Response, 2)
 }
 
 // fn main() {


### PR DESCRIPTION
`UnsafeCell`'s usage was incorrect. Instead of using `UnsafeCell` to get multiple `mut` references to the same memory, correct usage is to keep non-`mut` references to the `UnsafceCell` and use it to get mutable references to the underlying data exceptionally, when we are sure nothing else has a reference to the underlying data (of any type).