### PR TITLE
Impl Sync for Requester and Responder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -542,3 +542,6 @@ where
         }
     }
 }
+
+unsafe impl<I: Interchange> Sync for Requester<I> {}
+unsafe impl<I: Interchange> Sync for Responder<I> {}


### PR DESCRIPTION
This is sound because all the methods using `&self` only perform Atomic operations and don't touch the data.
All methods performing operations that require no concurrent operations take `&mut self`.