### PR TITLE
Add rustfmt and clippy to CI and deny warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,17 @@ jobs:
         toolchain: stable
         override: true
     - name: Build
-      run: cargo build --verbose
+      run: RUSTFLAGS="-D warnings" cargo build --verbose --all-targets --all-features
     - name: Run tests
       run: make test
-
     - name: Build Documentation
-      run: cargo doc --no-deps --all-features
+      run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+    - name: Run rustfmt
+      run: cargo fmt -- --check
+    - name: Run clippy
+      run: |
+        cargo clippy --all-targets --all-features -- --deny warnings
+        RUSTFLAGS='--cfg loom' cargo clippy --all-targets --all-features -- --deny warnings
     - name: Deploy Docs
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ test:
 	RUSTFLAGS='--cfg loom' cargo t loom
 
 clippy:
-	cargo clippy --all-targets
-	RUSTFLAGS='--cfg loom' cargo clippy --all-targets
+	cargo clippy --all-targets --all-features
+	RUSTFLAGS='--cfg loom' cargo clippy --all-targets --all-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -997,16 +997,16 @@ mod tests {
         let request = Request::This(1, 2);
         assert!(rq.request(request).is_ok());
         let request = rp.take_request().unwrap();
-        println!("rp got request: {:?}", request);
+        println!("rp got request: {request:?}");
         let response = Response::There(-1);
         assert!(!rp.is_canceled());
         assert!(rp.respond(response).is_ok());
         let response = rq.take_response().unwrap();
-        println!("rq got response: {:?}", response);
+        println!("rq got response: {response:?}");
         // early cancelation path
         assert!(rq.request(request).is_ok());
         let request = rq.cancel().unwrap().unwrap();
-        println!("responder could cancel: {:?}", request);
+        println!("responder could cancel: {request:?}");
         assert!(rp.take_request().is_none());
         assert_eq!(State::Idle, rq.state());
         // late cancelation
@@ -1026,7 +1026,7 @@ mod tests {
         assert!(rq.send_request().is_ok());
         let request = rp.take_request().unwrap();
         assert_eq!(request, Request::This(1, 2));
-        println!("rp got request: {:?}", request);
+        println!("rp got request: {request:?}");
         // building into response buffer
         rp.with_response_mut(|r| *r = Response::Here(3, 2, 1))
             .unwrap();
@@ -1046,16 +1046,16 @@ mod tests {
         let request = Request::This(1, 2);
         assert!(rq.request(request).is_ok());
         let request = rp.take_request().unwrap();
-        println!("rp got request: {:?}", request);
+        println!("rp got request: {request:?}");
         let response = Response::There(-1);
         assert!(!rp.is_canceled());
         assert!(rp.respond(response).is_ok());
         let response = rq.take_response().unwrap();
-        println!("rq got response: {:?}", response);
+        println!("rq got response: {response:?}");
         // early cancelation path
         assert!(rq.request(request).is_ok());
         let request = rq.cancel().unwrap().unwrap();
-        println!("responder could cancel: {:?}", request);
+        println!("responder could cancel: {request:?}");
         assert!(rp.take_request().is_none());
         assert_eq!(State::Idle, rq.state());
         // late cancelation
@@ -1075,7 +1075,7 @@ mod tests {
         assert!(rq.send_request().is_ok());
         let request = rp.take_request().unwrap();
         assert_eq!(request, Request::This(1, 2));
-        println!("rp got request: {:?}", request);
+        println!("rp got request: {request:?}");
         // building into response buffer
         rp.with_response_mut(|r| *r = Response::Here(3, 2, 1))
             .unwrap();


### PR DESCRIPTION
I think this could be used as a template for all Trussed repositories (except for the Deploy docs step).