### PR TITLE
Prepare release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Remove usage of macros and replace it with `const` and generics
+## [0.3.0][] - 2023-02-01
 
-## [0.2.2]- 2021-04-23
-- Soundness fix @sosthene-nitrokey
+- Remove usage of macros and replace it with `const` and generics ([#5][])
+  - Add tests using [loom][]
 
-## [0.2.0]- 2021-04-23
+[loom]: https://github.com/tokio-rs/loom
+[#5]: https://github.com/trussed-dev/interchange/pull/5
+
+## [0.2.2][] - 2022-08-22
+
+- Soundness fix ([#4][])
+
+[#4]: https://github.com/trussed-dev/interchange/pull/4
+
+## [0.2.0][] - 2021-04-23
 
 - Changes API to use references instead of moves.
   This improves stack usage.
+
+[Unreleased]: https://github.com/trussed-dev/interchange/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/trussed-dev/interchange/compare/0.2.2...0.3.0
+[0.2.2]: https://github.com/trussed-dev/interchange/compare/0.2.0...0.2.2
+[0.2.0]: https://github.com/trussed-dev/interchange/compare/0.1.2...0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "interchange"
 version = "0.3.0"
-authors = ["Nicolas Stalder <n@stalder.io>"]
+authors = ["The Trussed developers", "Nicolas Stalder <n@stalder.io>"]
 edition = "2018"
 description = "Request/response mechanism for embedded development, using atomics"
 repository = "https://github.com/trussed-dev/interchange"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interchange"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Nicolas Stalder <n@stalder.io>"]
 edition = "2018"
 description = "Request/response mechanism for embedded development, using atomics"


### PR DESCRIPTION
@nickray can you please create the tags for the previous releases?

`0.2.0`: 8a21982f41c5bc141240e2c87cbe7f6aad9ab8d0
`0.2.2`: 46bf22ccb741541d8194b02dd28dc4d71e5ab0ed
`0.3.0` this merge commit.