### PR TITLE
Fix Send and Sync implementations for Channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed 
+
+- Restrict `Send` and `Sync` trait implementations to disallow non thread-safe Request and Replies ([#11][])
+
+[#11]: https://github.com/trussed-dev/interchange/pull/11
+
 ## [0.3.0][] - 2023-02-01
 
 - Remove usage of macros and replace it with `const` and generics ([#5][])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -847,10 +847,14 @@ where
     }
 }
 
-unsafe impl<'i, Rq, Rp> Send for Responder<'i, Rq, Rp> {}
-unsafe impl<'i, Rq, Rp> Send for Requester<'i, Rq, Rp> {}
-unsafe impl<Rq, Rp> Send for Channel<Rq, Rp> {}
-unsafe impl<Rq, Rp> Sync for Channel<Rq, Rp> {}
+// Safety: The channel can be split, which then allows getting sending the Rq and Rp types across threads
+// TODO: is the Sync bound really necessary?
+unsafe impl<Rq, Rp> Sync for Channel<Rq, Rp>
+where
+    Rq: Send + Sync,
+    Rp: Send + Sync,
+{
+}
 
 /// Set of `N` channels
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -969,6 +969,56 @@ impl<Rq, Rp, const N: usize> Default for Interchange<Rq, Rp, N> {
     }
 }
 
+/// ```compile_fail
+/// use std::rc::Rc;
+/// use interchange::*;
+/// #[allow(unconditional_recursion, unused)]
+/// fn assert_send<T: Send>() {
+///     assert_send::<Channel<Rc<String>, u32>>();
+/// }
+/// ```
+/// ```compile_fail
+/// use std::rc::Rc;
+/// use interchange::*;
+/// #[allow(unconditional_recursion, unused)]
+/// fn assert_send<T: Send>() {
+///     assert_send::<Requester<Rc<String>, u32>>();
+/// }
+/// ```
+/// ```compile_fail
+/// use std::rc::Rc;
+/// use interchange::*;
+/// #[allow(unconditional_recursion, unused)]
+/// fn assert_send<T: Send>() {
+///     assert_send::<Responder<Rc<String>, u32>>();
+/// }
+/// ```
+/// ```compile_fail
+/// use std::rc::Rc;
+/// use interchange::*;
+/// #[allow(unconditional_recursion, unused)]
+/// fn assert_sync<T: Sync>() {
+///     assert_sync::<Channel<Rc<String>, u32>>();
+/// }
+/// ```
+/// ```compile_fail
+/// use std::rc::Rc;
+/// use interchange::*;
+/// #[allow(unconditional_recursion, unused)]
+/// fn assert_sync<T: Sync>() {
+///     assert_sync::<Requester<Rc<String>, u32>>();
+/// }
+/// ```
+/// ```compile_fail
+/// use std::rc::Rc;
+/// use interchange::*;
+/// #[allow(unconditional_recursion, unused)]
+/// fn assert_sync<T: Sync>() {
+///     assert_sync::<Responder<Rc<String>, u32>>();
+/// }
+/// ```
+const _ASSERT_COMPILE_FAILS: () = {};
+
 #[cfg(all(not(loom), test))]
 mod tests {
     use super::*;
@@ -1086,5 +1136,26 @@ mod tests {
         assert!(rp.send_response().is_ok());
         let response = rq.take_response().unwrap();
         assert_eq!(response, Response::Here(3, 2, 1));
+    }
+
+    #[allow(unconditional_recursion, unused)]
+    fn assert_send<T: Send>() {
+        assert_send::<Channel<String, u32>>();
+        assert_send::<Responder<'static, String, u32>>();
+        assert_send::<Requester<'static, String, u32>>();
+        assert_send::<Channel<&'static mut String, u32>>();
+        assert_send::<Responder<'static, &'static mut String, u32>>();
+        assert_send::<Requester<'static, &'static mut String, u32>>();
+    }
+    #[allow(unconditional_recursion, unused)]
+    fn assert_sync<T: Sync>() {
+        assert_sync::<Channel<String, u32>>();
+        assert_sync::<Channel<String, u32>>();
+        assert_sync::<Responder<'static, String, u32>>();
+        assert_sync::<Requester<'static, String, u32>>();
+
+        assert_sync::<Channel<&'static mut String, u32>>();
+        assert_sync::<Responder<'static, &'static mut String, u32>>();
+        assert_sync::<Requester<'static, &'static mut String, u32>>();
     }
 }


### PR DESCRIPTION
Fix Send and Sync implementations for Channel

Channel should not be usable to use with non Send/Sync messages types
because it allows transfering types across threads
This patch also relies on the auto trait implementations for Requester/Responder.

This is technically a breaking change, but I don't think it should be a major release.
This is unlikely to affect anyone, and if it does, it's probably uncovering unsoundness