### PR TITLE
Add support for interrupt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -767,10 +767,14 @@ impl<'i, Rq, Rp> Responder<'i, Rq, Rp> {
             unsafe {
                 self.with_data_mut(|i| *i = Message::from_rp(response));
             }
-            self.channel
-                .state
-                .store(State::Responded as u8, Ordering::Release);
-            Ok(())
+            if self
+                .channel
+                .transition(State::BuildingResponse, State::Responded)
+            {
+                Ok(())
+            } else {
+                Err(Error)
+            }
         } else {
             Err(Error)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,7 +404,7 @@ impl<Rq, Rp> Channel<Rq, Rp> {
 
     fn transition(&self, from: State, to: State) -> bool {
         self.state
-            .compare_exchange(from as u8, to as u8, Ordering::SeqCst, Ordering::SeqCst)
+            .compare_exchange(from as u8, to as u8, Ordering::AcqRel, Ordering::Relaxed)
             .is_ok()
     }
 }

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{
 };
 
 #[allow(deprecated)]
-static BRANCHES_USED: [AtomicBool; 6] = [ATOMIC_BOOL_INIT; 6];
+static BRANCHES_USED: [AtomicBool; 8] = [ATOMIC_BOOL_INIT; 8];
 
 #[test]
 fn loom_interchange() {
@@ -53,7 +53,13 @@ fn requester_thread(mut requester: Requester<'static, u64, u64>) -> Option<()> {
         Ok(_) => panic!("Invalid state"),
         Err(_) => {
             BRANCHES_USED[1].store(true, Release);
-            assert_eq!(requester.take_response().unwrap(), 79);
+            match requester.take_response() {
+                Some(i) => {
+                    assert_eq!(i, 79);
+                    BRANCHES_USED[6].store(true, Release);
+                }
+                None => BRANCHES_USED[7].store(true, Release),
+            }
         }
     }
     BRANCHES_USED[4].store(true, Release);

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{
 };
 
 #[allow(deprecated)]
-static BRANCHES_USED: [AtomicBool; 11] = [ATOMIC_BOOL_INIT; 11];
+static BRANCHES_USED: [AtomicBool; 14] = [ATOMIC_BOOL_INIT; 14];
 
 #[test]
 fn loom_interchange() {
@@ -42,14 +42,24 @@ fn loom_interchange() {
 
 fn requester_thread(mut requester: Requester<'static, u64, u64>) -> Option<()> {
     requester.request(53).unwrap();
+    match requester.cancel() {
+        Ok(Some(53) | None) => {
+            BRANCHES_USED[0].store(true, Release);
+            return None;
+        }
+        Ok(_) => panic!("Invalid state"),
+        Err(_) => {
+            BRANCHES_USED[1].store(true, Release);
+        }
+    }
     requester
         .with_response(|r| {
-            BRANCHES_USED[0].store(true, Release);
+            BRANCHES_USED[2].store(true, Release);
             assert_eq!(*r, 63)
         })
         .ok()
         .or_else(|| {
-            BRANCHES_USED[1].store(true, Release);
+            BRANCHES_USED[3].store(true, Release);
             None
         })?;
     requester.with_response(|r| assert_eq!(*r, 63)).unwrap();
@@ -58,44 +68,47 @@ fn requester_thread(mut requester: Requester<'static, u64, u64>) -> Option<()> {
     requester.send_request().unwrap();
     thread::yield_now();
     match requester.cancel() {
-        Ok(Some(51) | None) => BRANCHES_USED[2].store(true, Release),
+        Ok(Some(51) | None) => BRANCHES_USED[4].store(true, Release),
         Ok(_) => panic!("Invalid state"),
         Err(_) => {
-            BRANCHES_USED[3].store(true, Release);
+            BRANCHES_USED[5].store(true, Release);
             match requester.take_response() {
                 Some(i) => {
                     assert_eq!(i, 79);
-                    BRANCHES_USED[4].store(true, Release);
+                    BRANCHES_USED[6].store(true, Release);
                 }
-                None => BRANCHES_USED[5].store(true, Release),
+                None => BRANCHES_USED[7].store(true, Release),
             }
         }
     }
-    BRANCHES_USED[6].store(true, Release);
+    BRANCHES_USED[8].store(true, Release);
     None
 }
 
 fn responder_thread(mut responder: Responder<'static, u64, u64>) -> Option<()> {
     let req = responder.take_request().or_else(|| {
-        BRANCHES_USED[7].store(true, Release);
+        BRANCHES_USED[9].store(true, Release);
         None
     })?;
     assert_eq!(req, 53);
-    responder.respond(req + 10).unwrap();
+    responder.respond(req + 10).ok().or_else(|| {
+        BRANCHES_USED[10].store(true, Release);
+        None
+    })?;
     thread::yield_now();
     responder
         .with_request(|r| {
-            BRANCHES_USED[8].store(true, Release);
+            BRANCHES_USED[11].store(true, Release);
             assert_eq!(*r, 51)
         })
         .map(|_| assert!(responder.with_request(|_| {}).is_err()))
         .or_else(|_| {
-            BRANCHES_USED[9].store(true, Release);
+            BRANCHES_USED[12].store(true, Release);
             responder.acknowledge_cancel()
         })
         .ok()?;
     responder.with_response_mut(|r| *r = 79).ok();
     responder.send_response().ok();
-    BRANCHES_USED[10].store(true, Release);
+    BRANCHES_USED[13].store(true, Release);
     None
 }

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{
 };
 
 #[allow(deprecated)]
-static BRANCHES_USED: [AtomicBool; 8] = [ATOMIC_BOOL_INIT; 8];
+static BRANCHES_USED: [AtomicBool; 11] = [ATOMIC_BOOL_INIT; 11];
 
 #[test]
 fn loom_interchange() {
@@ -42,48 +42,60 @@ fn loom_interchange() {
 
 fn requester_thread(mut requester: Requester<'static, u64, u64>) -> Option<()> {
     requester.request(53).unwrap();
-    requester.with_response(|r| assert_eq!(*r, 63)).ok()?;
-    requester.with_response(|r| assert_eq!(*r, 63)).ok()?;
+    requester
+        .with_response(|r| {
+            BRANCHES_USED[0].store(true, Release);
+            assert_eq!(*r, 63)
+        })
+        .ok()
+        .or_else(|| {
+            BRANCHES_USED[1].store(true, Release);
+            None
+        })?;
+    requester.with_response(|r| assert_eq!(*r, 63)).unwrap();
     requester.take_response().unwrap();
     requester.with_request_mut(|r| *r = 51).unwrap();
     requester.send_request().unwrap();
     thread::yield_now();
     match requester.cancel() {
-        Ok(Some(51) | None) => BRANCHES_USED[0].store(true, Release),
+        Ok(Some(51) | None) => BRANCHES_USED[2].store(true, Release),
         Ok(_) => panic!("Invalid state"),
         Err(_) => {
-            BRANCHES_USED[1].store(true, Release);
+            BRANCHES_USED[3].store(true, Release);
             match requester.take_response() {
                 Some(i) => {
                     assert_eq!(i, 79);
-                    BRANCHES_USED[6].store(true, Release);
+                    BRANCHES_USED[4].store(true, Release);
                 }
-                None => BRANCHES_USED[7].store(true, Release),
+                None => BRANCHES_USED[5].store(true, Release),
             }
         }
     }
-    BRANCHES_USED[4].store(true, Release);
+    BRANCHES_USED[6].store(true, Release);
     None
 }
 
 fn responder_thread(mut responder: Responder<'static, u64, u64>) -> Option<()> {
-    let req = responder.take_request()?;
+    let req = responder.take_request().or_else(|| {
+        BRANCHES_USED[7].store(true, Release);
+        None
+    })?;
     assert_eq!(req, 53);
     responder.respond(req + 10).unwrap();
     thread::yield_now();
     responder
         .with_request(|r| {
-            BRANCHES_USED[2].store(true, Release);
+            BRANCHES_USED[8].store(true, Release);
             assert_eq!(*r, 51)
         })
         .map(|_| assert!(responder.with_request(|_| {}).is_err()))
         .or_else(|_| {
-            BRANCHES_USED[3].store(true, Release);
+            BRANCHES_USED[9].store(true, Release);
             responder.acknowledge_cancel()
         })
         .ok()?;
     responder.with_response_mut(|r| *r = 79).ok();
     responder.send_response().ok();
-    BRANCHES_USED[5].store(true, Release);
+    BRANCHES_USED[10].store(true, Release);
     None
 }


### PR DESCRIPTION
Motivation: https://github.com/trussed-dev/trussed/discussions/124

This PR contains a bit more than just the added Interrupt method on the channel:

- It reduces duplication by moving the transition method to the channel
- It fixes a race condition in the `respond` implementation:
Since the check of `State::BuildingResponse == self.channel.state.load(Ordering::Acquire)` was distinct from the `self.channel.state.store(State::Responded, …)`, the request could be cancelled while the response was written. a3cad6d771a465ecc4623e8c46de2461ef9b5988 adds the fix and updates `tests/loom.rs` to trigger this case.
- It relaxes the ordering of the `transition` method.
The first ordering of no operation relies on SeqCst semantics.
All works with Acquire/Release semantics, so there is no reason to use the SeqCst ordering.
The second ordering argument is for the failure, in which case we don't read any data,
and therefore don't need any synchronization.

 