### PR TITLE
Remove workaround using inline consts (stable in 1.79)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/interchange"
 keywords = ["cortex-m", "nxp", "lpc"]
 categories = ["development-tools", "embedded"]
+rust-version = "1.79"
 
 [target.'cfg(loom)'.dependencies]
 loom = "0.5"


### PR DESCRIPTION
This bumps MSRV to 1.79, so I'm not sure it's worth merging now, but we might as well have it for the future.