### PR TITLE
Prepare release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed 
 
+## [0.3.1][] - 2024-06-20
+
+### Changed 
+
 - Restrict `Send` and `Sync` trait implementations to disallow non thread-safe Request and Replies ([#11][])
 
 [#11]: https://github.com/trussed-dev/interchange/pull/11
@@ -31,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changes API to use references instead of moves.
   This improves stack usage.
 
-[Unreleased]: https://github.com/trussed-dev/interchange/compare/0.3.0...HEAD
+[Unreleased]: https://github.com/trussed-dev/interchange/compare/0.3.1...HEAD
+[0.3.1]: https://github.com/trussed-dev/interchange/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/trussed-dev/interchange/compare/0.2.2...0.3.0
 [0.2.2]: https://github.com/trussed-dev/interchange/compare/0.2.0...0.2.2
 [0.2.0]: https://github.com/trussed-dev/interchange/compare/0.1.2...0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interchange"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The Trussed developers", "Nicolas Stalder <n@stalder.io>"]
 edition = "2018"
 description = "Request/response mechanism for embedded development, using atomics"


### PR DESCRIPTION
This is technically a breaking change, but it is a bugfix. If someone is hit by the break, they relying on unsound implementations